### PR TITLE
refactor: update user approval logic and model attributes

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,7 +35,8 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         'avatar',
         'office_id',
         'section_id',
-        'is_approved',
+        'approved_by',
+        'approved_at',
         'deactivated_at',
         'deactivated_by',
     ];
@@ -55,16 +56,12 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
      *
      * @return array<string, string>
      */
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-            'role' => UserRole::class,
-            'deactivated_at' => 'datetime',
-            'is_approved' => 'boolean',
-        ];
-    }
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password'          => 'hashed',
+        'role'              => UserRole::class,
+        'deactivated_at'    => 'datetime',
+    ];
 
     public function deactivate(User $deactivatedBy): void
     {
@@ -108,7 +105,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         return $this->belongsTo(Section::class);
     }
 
-    public function approve(?Auth $user = null): void
+    public function approve(?User $user = null): void
     {
         $this->update([
             'approved_by' => $user?->id ?? Auth::id(),
@@ -123,6 +120,6 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
 
     public function hasApprovedAccount(): bool
     {
-        return $this->hasVerifiedEmail() && $this->is_approved;
+        return $this->hasVerifiedEmail() && isset($this->approved_at);
     }
 }


### PR DESCRIPTION
This pull request refactors the approval and deactivation logic for users, replacing the `is_approved` boolean field with `approved_at` and `approved_by` fields to support more detailed tracking. Additionally, it simplifies some method calls and improves code readability. Below are the most important changes grouped by theme:

### Approval Logic Updates:
* Replaced the `is_approved` field in the `User` model with `approved_at` (datetime) and `approved_by` (user ID) to better track approval details. (`app/Models/User.php`)
* Updated the `approve` method in the `User` model to set `approved_by` and `approved_at` fields instead of toggling a boolean. (`app/Models/User.php`)
* Modified the `hasApprovedAccount` method to check for the presence of `approved_at` instead of the `is_approved` boolean. (`app/Models/User.php`)

### Filament Resource Adjustments:
* Replaced `is_approved` with `approved_at` in the `TernaryFilter` for the Users table, updating query logic to reflect the new field. (`app/Filament/Resources/UserResource.php`)
* Updated visibility logic for the "Approve" action in the Users table to check for `approved_at` instead of `is_approved`. (`app/Filament/Resources/UserResource.php`)

### Code Simplifications:
* Replaced the `getOptionLabelUsing` callback in the `form` method with `optional()` to simplify null handling. (`app/Filament/Resources/UserResource.php`)
* Simplified the `deactivate` action in the Users table by directly passing the authenticated user instead of requiring it as a parameter. (`app/Filament/Resources/UserResource.php`)

These changes improve the maintainability and functionality of the user management system by providing more detailed tracking for approvals and simplifying code where possible.