### PR TITLE
fix: add missing middleware for user authentication

### DIFF
--- a/app/Providers/Filament/UserPanelProvider.php
+++ b/app/Providers/Filament/UserPanelProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\Approve;
 use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\Verify;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -16,6 +18,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\App;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class UserPanelProvider extends PanelProvider
@@ -51,6 +54,8 @@ class UserPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
+                Verify::class,
+                Approve::class,
             ]);
     }
 }


### PR DESCRIPTION
This pull request updates the `UserPanelProvider` class to enhance middleware functionality by adding new middleware for verification and approval processes.

### Middleware Enhancements:

* Added `Verify` and `Approve` middleware to the `authMiddleware` array in the `panel` method to enforce additional verification and approval steps for user authentication. (`[app/Providers/Filament/UserPanelProvider.phpR57-R58](diffhunk://#diff-62aca62d2a5be12782eae46ade572d61abdf08dd00316e3f1b2c974ac2a41eefR57-R58)`)
* Imported the `Verify` and `Approve` middleware classes to ensure they are available for use in the `UserPanelProvider` class. (`[app/Providers/Filament/UserPanelProvider.phpR5-R7](diffhunk://#diff-62aca62d2a5be12782eae46ade572d61abdf08dd00316e3f1b2c974ac2a41eefR5-R7)`)

### Other Changes:

* Imported the `App` facade from `Illuminate\Support\Facades` to potentially support additional functionality within the `UserPanelProvider` class. (`[app/Providers/Filament/UserPanelProvider.phpR21](diffhunk://#diff-62aca62d2a5be12782eae46ade572d61abdf08dd00316e3f1b2c974ac2a41eefR21)`)