### PR TITLE
Feat/source resource

### DIFF
--- a/app/Filament/Actions/Concerns/TransmitDocument.php
+++ b/app/Filament/Actions/Concerns/TransmitDocument.php
@@ -45,7 +45,7 @@ trait TransmitDocument
                 ->required()
                 ->live()
                 ->afterStateUpdated(function ($state, callable $set) {
-                    if (!$state) {
+                    if (! $state) {
                         $set('section_id', null);
                     }
                 }),
@@ -54,13 +54,13 @@ trait TransmitDocument
                 ->options(function (Get $get) {
                     $officeId = $get('office_id');
 
-                    if (!$officeId) {
+                    if (! $officeId) {
                         return [];
                     }
 
                     $office = Office::find($officeId);
 
-                    if (!$office || $office->id !== Auth::user()->office_id) {
+                    if (! $office || $office->id !== Auth::user()->office_id) {
                         return [];
                     }
 
@@ -69,7 +69,7 @@ trait TransmitDocument
                 })
                 ->searchable()
                 ->preload()
-                ->visible(fn(Get $get) => $get('office_id') === Auth::user()->office_id),
+                ->visible(fn (Get $get) => $get('office_id') === Auth::user()->office_id),
             Select::make('liaison_id')
                 ->label('Liaison')
                 ->options(function (callable $get) {
@@ -116,11 +116,10 @@ trait TransmitDocument
             }
         });
 
-        $this->visible(fn (Document $record): bool =>
-            $record->isPublished() &&
+        $this->visible(fn (Document $record): bool => $record->isPublished() &&
             $record->user_id === Auth::id() &&
-            !$record->transmitted_at &&
-            !$record->dissemination
+            ! $record->transmitted_at &&
+            ! $record->dissemination
         );
 
         $this->successNotificationTitle('Document transmitted successfully');

--- a/app/Filament/Actions/PublishDocumentAction.php
+++ b/app/Filament/Actions/PublishDocumentAction.php
@@ -5,7 +5,6 @@ namespace App\Filament\Actions;
 use App\Models\Document;
 use Exception;
 use Filament\Actions\Action;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class PublishDocumentAction extends Action

--- a/app/Filament/Forms/AttachmentFileUpload.php
+++ b/app/Filament/Forms/AttachmentFileUpload.php
@@ -6,7 +6,6 @@ use Filament\Forms\Components\FileUpload;
 
 class AttachmentFileUpload extends FileUpload
 {
-
     public static function make(string $name = 'file'): static
     {
         $static = app(static::class, ['name' => $name]);

--- a/app/Filament/Resources/DocumentResource.php
+++ b/app/Filament/Resources/DocumentResource.php
@@ -101,7 +101,7 @@ class DocumentResource extends Resource
                             ->orderColumn('sort')
                             ->hint('Specify the attachments enclosed with the document')
                             ->helperText('What are the files or documents attached?')
-                            ->itemLabel(fn($state) => $state['title'])
+                            ->itemLabel(fn ($state) => $state['title'])
                             ->collapsed()
                             ->required()
                             ->schema([
@@ -110,9 +110,9 @@ class DocumentResource extends Resource
                                 Forms\Components\TextInput::make('title')
                                     ->rule('required')
                                     ->markAsRequired()
-                                    ->hidden(fn(callable $get) => $get('electronic')),
+                                    ->hidden(fn (callable $get) => $get('electronic')),
                                 Forms\Components\Grid::make(3)
-                                    ->hidden(fn(callable $get) => $get('electronic'))
+                                    ->hidden(fn (callable $get) => $get('electronic'))
                                     ->schema([
                                         Forms\Components\TextInput::make('context.control')
                                             ->label('Control #'),
@@ -129,7 +129,7 @@ class DocumentResource extends Resource
                                             ->rule('numeric'),
                                     ]),
                                 Forms\Components\Textarea::make('remarks')
-                                    ->hidden(fn(callable $get) => $get('electronic'))
+                                    ->hidden(fn (callable $get) => $get('electronic'))
                                     ->maxLength(4096),
                             ]),
                     ]),
@@ -179,7 +179,7 @@ class DocumentResource extends Resource
                         Infolists\Components\TextEntry::make('published_at')
                             ->label('Published At')
                             ->dateTime()
-                            ->visible(fn(Document $record): bool => $record->isPublished()),
+                            ->visible(fn (Document $record): bool => $record->isPublished()),
                     ]),
             ]);
     }
@@ -192,7 +192,7 @@ class DocumentResource extends Resource
                     ->label('Title')
                     ->searchable()
                     ->limit(60)
-                    ->tooltip(fn(Tables\Columns\TextColumn $column): ?string => $column->getState()),
+                    ->tooltip(fn (Tables\Columns\TextColumn $column): ?string => $column->getState()),
                 Tables\Columns\TextColumn::make('code')
                     ->label('Code')
                     ->searchable()
@@ -208,9 +208,9 @@ class DocumentResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
-                    ->color(fn(Document $record): string => $record->isPublished() ? 'success' : 'gray')
-                    ->formatStateUsing(fn(Document $record): string => $record->isPublished() ? 'Published' : 'Draft')
-                    ->getStateUsing(fn(Document $record): string => $record->isPublished() ? 'published' : 'draft'),
+                    ->color(fn (Document $record): string => $record->isPublished() ? 'success' : 'gray')
+                    ->formatStateUsing(fn (Document $record): string => $record->isPublished() ? 'Published' : 'Draft')
+                    ->getStateUsing(fn (Document $record): string => $record->isPublished() ? 'published' : 'draft'),
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Created By')
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -230,7 +230,7 @@ class DocumentResource extends Resource
                     ->query(function (Builder $query, array $data): Builder {
                         return $query->when(
                             @$data['value'],
-                            fn(Builder $query, $value): Builder => match ($value) {
+                            fn (Builder $query, $value): Builder => match ($value) {
                                 'draft' => $query->whereNull('published_at'),
                                 'published' => $query->whereNotNull('published_at'),
                                 default => $query,
@@ -247,7 +247,7 @@ class DocumentResource extends Resource
                     ->label('QR')
                     ->icon('heroicon-o-qr-code')
                     ->modalWidth('md')
-                    ->visible(fn(Document $record): bool => $record->isPublished())
+                    ->visible(fn (Document $record): bool => $record->isPublished())
                     ->modalContent(function (Document $record) {
                         $qrCode = (new GenerateQR)($record->code);
 
@@ -276,7 +276,7 @@ class DocumentResource extends Resource
                 Tables\Actions\ActionGroup::make([
                     UnpublishDocumentAction::make(),
                     Tables\Actions\EditAction::make()
-                        ->visible(fn(Document $record): bool => $record->isDraft()),
+                        ->visible(fn (Document $record): bool => $record->isDraft()),
                     Tables\Actions\RestoreAction::make(),
                     Tables\Actions\ForceDeleteAction::make(),
                 ]),

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Forms;
+use Filament\Tables;
+use App\Models\Source;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use App\Filament\Resources\SourceResource\Pages;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use App\Filament\Resources\SourceResource\RelationManagers;
+use App\Filament\Resources\SourceResource\RelationManager\DocumentRelationManager;
+
+class SourceResource extends Resource
+{
+    protected static ?string $model = Source::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name') 
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make()
+                    ->slideOver()
+                    ->modalWidth('md'),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            DocumentRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSources::route('/'),
+            'view' => Pages\ViewSources::route('/{record}'),
+            
+        ];
+    }
+}

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -34,6 +34,11 @@ class SourceResource extends Resource
                     ->autofocus()
                     ->columnSpanFull()
                     ->live(),
+                Forms\Components\Textarea::make('description')
+                    ->maxLength(255)
+                    ->placeholder('Enter classification description')
+                    ->rows(2)
+                    ->columnSpanFull(),
             ]);
     }
 

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -15,7 +15,7 @@ class SourceResource extends Resource
 {
     protected static ?string $model = Source::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+    protected static ?string $navigationIcon = 'heroicon-o-inbox-stack';
 
     public static function form(Form $form): Form
     {
@@ -24,7 +24,6 @@ class SourceResource extends Resource
                 Forms\Components\TextInput::make('name')
                     ->required()
                     ->maxLength(255)
-                    ->label('Source Name')
                     ->placeholder('Enter source name')
                     ->autofocus()
                     ->columnSpanFull()

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -2,19 +2,14 @@
 
 namespace App\Filament\Resources;
 
-use Filament\Forms;
-use Filament\Tables;
-use App\Models\Source;
-use Filament\Forms\Form;
-use Filament\Tables\Table;
-use Filament\Resources\Resource;
-use Illuminate\Database\Eloquent\Builder;
 use App\Filament\Resources\SourceResource\Pages;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use App\Filament\Resources\SourceResource\RelationManagers;
 use App\Filament\Resources\SourceResource\RelationManager\DocumentRelationManager;
-
-use function Laravel\Prompts\text;
+use App\Models\Source;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
 
 class SourceResource extends Resource
 {
@@ -46,7 +41,7 @@ class SourceResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('name') 
+                Tables\Columns\TextColumn::make('name')
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('description')
@@ -77,7 +72,7 @@ class SourceResource extends Resource
         return [
             'index' => Pages\ListSources::route('/'),
             'view' => Pages\ViewSources::route('/{record}'),
-            
+
         ];
     }
 }

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -30,13 +30,13 @@ class SourceResource extends Resource
                     ->required()
                     ->maxLength(255)
                     ->label('Source Name')
-                    ->placeholder('Enter the source name')
+                    ->placeholder('Enter source name')
                     ->autofocus()
                     ->columnSpanFull()
                     ->live(),
                 Forms\Components\Textarea::make('description')
                     ->maxLength(255)
-                    ->placeholder('Enter classification description')
+                    ->placeholder('Enter source description')
                     ->rows(2)
                     ->columnSpanFull(),
             ]);
@@ -48,8 +48,11 @@ class SourceResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('name') 
                     ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('description')
+                    ->searchable()
                     ->sortable()
-                    ->limit(50),
+                    ->placeholder('No description provided'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/SourceResource.php
+++ b/app/Filament/Resources/SourceResource.php
@@ -14,17 +14,26 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use App\Filament\Resources\SourceResource\RelationManagers;
 use App\Filament\Resources\SourceResource\RelationManager\DocumentRelationManager;
 
+use function Laravel\Prompts\text;
+
 class SourceResource extends Resource
 {
     protected static ?string $model = Source::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                //
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->label('Source Name')
+                    ->placeholder('Enter the source name')
+                    ->autofocus()
+                    ->columnSpanFull()
+                    ->live(),
             ]);
     }
 

--- a/app/Filament/Resources/SourceResource/Pages/ListSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ListSources.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\SourceResource\Pages;
+
+use App\Filament\Resources\SourceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSources extends ListRecords
+{
+    protected static string $resource = SourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+            ->slideOver()
+            ->modalWidth('md'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SourceResource/Pages/ListSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ListSources.php
@@ -14,9 +14,9 @@ class ListSources extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-            ->slideOver()
-            ->modalWidth('md')
-            ->createAnother(false),
+                ->slideOver()
+                ->modalWidth('md')
+                ->createAnother(false),
         ];
     }
 }

--- a/app/Filament/Resources/SourceResource/Pages/ListSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ListSources.php
@@ -15,7 +15,8 @@ class ListSources extends ListRecords
         return [
             Actions\CreateAction::make()
             ->slideOver()
-            ->modalWidth('md'),
+            ->modalWidth('md')
+            ->createAnother(false),
         ];
     }
 }

--- a/app/Filament/Resources/SourceResource/Pages/ViewSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ViewSources.php
@@ -1,23 +1,22 @@
 <?php
 
 namespace App\Filament\Resources\SourceResource\Pages;
+
+use App\Filament\Resources\SourceResource;
 use Filament\Actions;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
-use App\Filament\Resources\SourceResource;
-use Filament\Infolists\Components\TextEntry;
-
-
-
-
 
 class ViewSources extends ViewRecord
 {
     protected static string $resource = SourceResource::class;
+
     public function getTitle(): string
     {
         return $this->record->name;
     }
+
     public function infolist(Infolist $infolist): Infolist
     {
         return $infolist
@@ -27,6 +26,7 @@ class ViewSources extends ViewRecord
                     ->placeholder('No description provided'),
             ]);
     }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Resources/SourceResource/Pages/ViewSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ViewSources.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Resources\SourceResource\Pages;
+use App\Filament\Resources\SourceResource;
+use Filament\Resources\Pages\ViewRecord;
+use Filament\Actions;
+
+
+
+
+
+class ViewSources extends ViewRecord
+{
+    protected static string $resource = SourceResource::class;
+    public function getTitle(): string
+    {
+        return $this->record->name;
+    }
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+
+        ];
+    }
+}

--- a/app/Filament/Resources/SourceResource/Pages/ViewSources.php
+++ b/app/Filament/Resources/SourceResource/Pages/ViewSources.php
@@ -1,9 +1,11 @@
 <?php
 
 namespace App\Filament\Resources\SourceResource\Pages;
-use App\Filament\Resources\SourceResource;
-use Filament\Resources\Pages\ViewRecord;
 use Filament\Actions;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Pages\ViewRecord;
+use App\Filament\Resources\SourceResource;
+use Filament\Infolists\Components\TextEntry;
 
 
 
@@ -15,6 +17,15 @@ class ViewSources extends ViewRecord
     public function getTitle(): string
     {
         return $this->record->name;
+    }
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                TextEntry::make('description')
+                    ->hiddenLabel(true)
+                    ->placeholder('No description provided'),
+            ]);
     }
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
+++ b/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
@@ -7,8 +7,6 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DocumentRelationManager extends RelationManager
 {

--- a/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
+++ b/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
@@ -38,8 +38,8 @@ class DocumentRelationManager extends RelationManager
                     ->label('Office')
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('classification.name')
-                    ->label('Classification')
+                Tables\Columns\TextColumn::make('source.name')
+                    ->label('Source')
                     ->searchable()
                     ->sortable(),
             ])

--- a/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
+++ b/app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Filament\Resources\SourceResource\RelationManager;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class DocumentRelationManager extends RelationManager
+{
+    protected static string $relationship = 'documents';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50)
+                    ->url(fn ($record) => route('filament.app.resources.documents.view', $record->id)),
+                Tables\Columns\TextColumn::make('office.name')
+                    ->label('Office')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('classification.name')
+                    ->label('Classification')
+                    ->searchable()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -12,10 +12,12 @@ class Source extends Model
 
     protected $fillable = [
         'name',
+        'description',
     ];
 
     public function documents(): HasMany
     {
         return $this->hasMany(Document::class);
     }
+
 }

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -19,5 +19,4 @@ class Source extends Model
     {
         return $this->hasMany(Document::class);
     }
-
 }

--- a/app/Models/Transmittal.php
+++ b/app/Models/Transmittal.php
@@ -79,7 +79,7 @@ class Transmittal extends Model
             $faker = fake()->unique();
 
             do {
-                $codes = collect(range(1, 10))->map(fn() => $faker->bothify('??????????'))->toArray();
+                $codes = collect(range(1, 10))->map(fn () => $faker->bothify('??????????'))->toArray();
 
                 $available = array_diff($codes, self::whereIn('code', $codes)->pluck('code')->toArray());
             } while (empty($available));

--- a/database/migrations/2025_04_07_000004_create_sources_table.php
+++ b/database/migrations/2025_04_07_000004_create_sources_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('sources', function (Blueprint $table) {
             $table->ulid('id')->primary();
             $table->string('name');
+            $table->string('description')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This pull request introduces a new `SourceResource` in the Filament admin panel, along with its associated pages and relation manager. The changes provide functionality for managing `Source` records, including listing, viewing, and managing related `Document` records.

### Addition of `SourceResource`:

* [`app/Filament/Resources/SourceResource.php`](diffhunk://#diff-12dc7482ed40919124468099bf5e642af4c2eee823484e79e9a0ed13ad0fc3c6R1-R66): Added a new `SourceResource` class to define the resource's form, table, relations, and pages. It includes searchable and sortable columns for `name`, and actions like view and edit.

### Pages for `SourceResource`:

* [`app/Filament/Resources/SourceResource/Pages/ListSources.php`](diffhunk://#diff-4f59863c5f2cc6935627a664b9eaf909f4a795ff1749f24a82733b27226e8320R1-R21): Added a `ListSources` page for listing `Source` records, with a header action to create new records using a slide-over modal.
* [`app/Filament/Resources/SourceResource/Pages/ViewSources.php`](diffhunk://#diff-232cdd24aa2bff831d4755c2f2e58b2c9d3f09b1048cb5c18165cd226757607bR1-R33): Added a `ViewSources` page for viewing individual `Source` records, with actions for editing and deleting records. The page dynamically sets the title based on the record's name.

### Relation Manager for Documents:

* [`app/Filament/Resources/SourceResource/RelationManager/DocumentRelationManager.php`](diffhunk://#diff-d167d65c52efa8629f2c453b541e5ae6a2ad56d839ba2817e40796abe75b456aR1-R62): Added a `DocumentRelationManager` to manage `Document` records related to a `Source`. It includes a form for creating/editing documents and a table with searchable and sortable columns for `title`, `office.name`, and `source.name`. Actions include create, edit, delete, and bulk delete.