### PR TITLE
fix: add redirect after publishing document in EditDocument page

### DIFF
--- a/app/Filament/Resources/DocumentResource/Pages/EditDocument.php
+++ b/app/Filament/Resources/DocumentResource/Pages/EditDocument.php
@@ -15,7 +15,10 @@ class EditDocument extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            PublishDocumentAction::make(),
+            PublishDocumentAction::make()
+                ->after(function () {
+                    return redirect()->to(DocumentResource::getUrl('view', ['record' => $this->record]));
+                }),
             TransmitDocumentAction::make(),
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),


### PR DESCRIPTION
This pull request updates the `EditDocument` class in the `DocumentResource` to enhance user experience by adding a redirection after publishing a document.

### User experience improvement:

* [`app/Filament/Resources/DocumentResource/Pages/EditDocument.php`](diffhunk://#diff-eec01ecaaa5c75a31308163bb694db5fb1bff7472e0fbf519df97b178a3d38c0L18-R21): Modified the `PublishDocumentAction` in the `getHeaderActions` method to include an `after` callback. This callback redirects the user to the document's view page after the document is published.