### PR TITLE
Refactor: remove approved filter from UserResource table and add tabs…

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -170,14 +170,6 @@ class UserResource extends Resource
                         true: fn ($query) => $query->whereNull('deactivated_at'),
                         false: fn ($query) => $query->whereNotNull('deactivated_at'),
                     ),
-                Tables\Filters\TernaryFilter::make('approved_at')
-                    ->label('Approved')
-                    ->trueLabel('Approved')
-                    ->falseLabel('Pending')
-                    ->queries(
-                        true: fn ($query) => $query->whereNotNull('approved_at'),
-                        false: fn ($query) => $query->whereNull('approved_at'),
-                    ),
                 Tables\Filters\TrashedFilter::make('trashed')
                     ->label('Trashed'),
             ])

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -4,8 +4,23 @@ namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Resources\Components\Tab;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListUsers extends ListRecords
 {
     protected static string $resource = UserResource::class;
+
+    public function getTabs(): array
+    {
+        return [
+            'approved' => Tab::make('Approved')
+                ->modifyQueryUsing(fn (Builder $query) => $query->whereNotNull('approved_at'))
+                ->badge($this->getModel()::whereNotNull('approved_at')->count()),
+            
+            'pending' => Tab::make('Pending')
+                ->modifyQueryUsing(fn (Builder $query) => $query->whereNull('approved_at'))
+                ->badge($this->getModel()::whereNull('approved_at')->count()),
+        ];
+    }
 }


### PR DESCRIPTION
This pull request refactors the filtering and tabbing functionality in the `UserResource` to improve the user interface and code organization. The key changes include removing the ternary filter for the `approved_at` field and replacing it with a tab-based approach in the `ListUsers` page.

### Refactoring of filtering functionality:

* Removed the `TernaryFilter` for the `approved_at` field in the `table` method of `UserResource` to simplify the filter options. (`app/Filament/Resources/UserResource.php`, [app/Filament/Resources/UserResource.phpL173-L180](diffhunk://#diff-2a48e3a6a61e7a6254887a8a989c5d5a19f9b1b4552dc470cc973ff977e10ad7L173-L180))

### Introduction of tab-based UI:

* Added a `getTabs` method in `ListUsers` to introduce tabs for "Approved" and "Pending" users. Each tab modifies the query to filter records based on the `approved_at` field and displays a badge with the count of matching records. (`app/Filament/Resources/UserResource/Pages/ListUsers.php`, [app/Filament/Resources/UserResource/Pages/ListUsers.phpR7-R25](diffhunk://#diff-9ca63fbc532055432384c94c3c4968aab1593de9ad976a2ce8b07bc3d762cddcR7-R25))… for approved/pending users in ListUsers page