### PR TITLE
refactor/section-head-user

### DIFF
--- a/app/Models/Section.php
+++ b/app/Models/Section.php
@@ -8,17 +8,44 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Section extends Model
 {
     use HasFactory, HasUlids, SoftDeletes;
 
+    protected $with = ['head'];
+
     protected $fillable = [
         'name',
         'office_id',
+        'user_id',
         'head_name',
         'designation',
     ];
+
+    protected static function booted()
+    {
+        static::creating(function ($section) {
+            if ($section->user_id && !$section->head_name) {
+                $user = User::find($section->user_id);
+                if ($user) {
+                    $section->head_name = $user->name;
+                    $section->designation = $user->designation;
+                }
+            }
+        });
+
+        static::updating(function ($section) {
+            if ($section->isDirty('user_id') && $section->user_id) {
+                $user = User::find($section->user_id);
+                if ($user) {
+                    $section->head_name = $user->name;
+                    $section->designation = $user->designation;
+                }
+            }
+        });
+    }
 
     public function office(): BelongsTo
     {
@@ -35,8 +62,32 @@ class Section extends Model
         return $this->hasMany(Transmittal::class);
     }
 
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function head(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
     public function users(): HasMany
     {
         return $this->hasMany(User::class);
+    }
+
+    public function sectionHeadName(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $this->head?->name ?? $this->head_name,
+        );
+    }
+
+    public function sectionHeadDesignation(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $this->head?->designation ?? $this->designation,
+        );
     }
 }

--- a/database/migrations/2025_08_13_080836_create_sections_table.php
+++ b/database/migrations/2025_08_13_080836_create_sections_table.php
@@ -4,6 +4,7 @@ use App\Models\Office;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\User;
 
 return new class extends Migration
 {
@@ -13,6 +14,7 @@ return new class extends Migration
             $table->ulid('id')->primary();
             $table->string('name');
             $table->foreignIdFor(Office::class)->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignIdFor(User::class)->nullable()->nullOnDelete()->cascadeOnUpdate();
             $table->string('head_name')->nullable();
             $table->string('designation')->nullable();
             $table->timestamps();


### PR DESCRIPTION
- Introduced a Select component for choosing a Section Head (User) in the SectionRelationManager.
- Updated Section model to handle user_id, head_name, and designation dynamically during creation and updates.
- Modified migration to include user_id as a foreign key in the sections table.
- Enhanced form validation to require head_name and designation only when no user is selected.